### PR TITLE
[DEMO] implement 'blueprint' as propName for styling (rather than 'theme')

### DIFF
--- a/packages/styled-components/src/constructors/createGlobalStyle.ts
+++ b/packages/styled-components/src/constructors/createGlobalStyle.ts
@@ -89,7 +89,7 @@ export default function createGlobalStyle<Props = unknown>(
     } else {
       const context = {
         ...props,
-        theme: determineTheme(props, theme, GlobalStyleComponent.defaultProps),
+        blueprint: determineTheme(props, theme, GlobalStyleComponent.defaultProps),
       } as ExecutionContext & Props;
 
       globalStyle.renderStyles(instance, context, styleSheet, stylis);

--- a/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
+++ b/packages/styled-components/src/constructors/test/createGlobalStyle.test.tsx
@@ -64,10 +64,10 @@ describe(`createGlobalStyle`, () => {
     const { render } = setup();
     const Component = createGlobalStyle({
       'h1, h2, h3, h4, h5, h6': {
-        fontFamily: ({ theme }) => theme.fonts.heading,
+        fontFamily: ({ blueprint }) => blueprint.fonts.heading,
       },
     });
-    render(<Component theme={{ fonts: { heading: 'sans-serif' } }} />);
+    render(<Component blueprint={{ fonts: { heading: 'sans-serif' } }} />);
     expect(getRenderedCSS()).toMatchInlineSnapshot(`
       "h1, h2, h3, h4, h5, h6 {
         font-family: sans-serif;
@@ -81,12 +81,12 @@ describe(`createGlobalStyle`, () => {
       'div, span': {
         h1: {
           span: {
-            fontFamily: ({ theme }) => theme.fonts.heading,
+            fontFamily: ({ blueprint }) => blueprint.fonts.heading,
           },
         },
       },
     });
-    render(<Component1 theme={{ fonts: { heading: 'sans-serif' } }} />);
+    render(<Component1 blueprint={{ fonts: { heading: 'sans-serif' } }} />);
     expect(getRenderedCSS()).toMatchInlineSnapshot(`
       "div h1 span, span h1 span {
         font-family: sans-serif;
@@ -96,9 +96,9 @@ describe(`createGlobalStyle`, () => {
 
   it(`supports theming`, () => {
     const { render } = context;
-    const Component = createGlobalStyle`div {color:${props => props.theme.color};} `;
+    const Component = createGlobalStyle`div {color:${props => props.blueprint.color};} `;
     render(
-      <ThemeProvider theme={{ color: 'black' }}>
+      <ThemeProvider blueprint={{ color: 'black' }}>
         <Component />
       </ThemeProvider>
     );
@@ -111,7 +111,7 @@ describe(`createGlobalStyle`, () => {
 
   it(`updates theme correctly`, () => {
     const { render } = context;
-    const Component = createGlobalStyle`div {color:${props => props.theme.color};} `;
+    const Component = createGlobalStyle`div {color:${props => props.blueprint.color};} `;
     let update: Function;
     class App extends React.Component {
       state = { color: 'grey' };
@@ -125,7 +125,7 @@ describe(`createGlobalStyle`, () => {
 
       render() {
         return (
-          <ThemeProvider theme={{ color: this.state.color }}>
+          <ThemeProvider blueprint={{ color: this.state.color }}>
             <Component />
           </ThemeProvider>
         );

--- a/packages/styled-components/src/hoc/withTheme.spec.tsx
+++ b/packages/styled-components/src/hoc/withTheme.spec.tsx
@@ -14,7 +14,7 @@ describe('withTheme', () => {
   it('should not throw an error when defaultProps is defined', () => {
     const Component = () => <div>Wrapped Component</div>;
     Component.defaultProps = {
-      theme: {},
+      blueprint: {},
     };
 
     const WrappedComponent = withTheme(Component);
@@ -44,7 +44,7 @@ describe('withTheme', () => {
     });
 
     const wrapper = TestRenderer.create(
-      <ThemeProvider theme={{ color: 'red' }}>
+      <ThemeProvider blueprint={{ color: 'red' }}>
         <WrappedComponent />
       </ThemeProvider>
     );

--- a/packages/styled-components/src/hooks/test/useTheme.test.tsx
+++ b/packages/styled-components/src/hooks/test/useTheme.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import TestRenderer from 'react-test-renderer';
 
-import ThemeProvider from '../../models/ThemeProvider';
 import withTheme from '../../hoc/withTheme';
-import useTheme from '../useTheme';
+import ThemeProvider from '../../models/ThemeProvider';
 import { resetStyled } from '../../test/utils';
+import useTheme from '../useTheme';
 
 let styled: ReturnType<typeof resetStyled>;
 
@@ -25,7 +25,7 @@ describe('useTheme', () => {
 
     const wrapper = TestRenderer.create(
       <div>
-        <ThemeProvider theme={mainTheme}>
+        <ThemeProvider blueprint={mainTheme}>
           <MyDivWithThemeOne />
           <MyDivWithThemeContext />
         </ThemeProvider>

--- a/packages/styled-components/src/models/StyledComponent.ts
+++ b/packages/styled-components/src/models/StyledComponent.ts
@@ -57,7 +57,7 @@ function useResolvedAttrs<Props = unknown>(
   // NOTE: can't memoize this
   // returns [context, resolvedAttrs]
   // where resolvedAttrs is only the things injected by the attrs themselves
-  const context: ExecutionContext & Props = { ...props, theme };
+  const context: ExecutionContext & Props = { ...props, blueprint: theme };
   const resolvedAttrs: BaseExtensibleObject = {};
 
   attrs.forEach(attrDef => {

--- a/packages/styled-components/src/models/StyledNativeComponent.ts
+++ b/packages/styled-components/src/models/StyledNativeComponent.ts
@@ -28,7 +28,7 @@ function useResolvedAttrs<Props = unknown>(
   // NOTE: can't memoize this
   // returns [context, resolvedAttrs]
   // where resolvedAttrs is only the things injected by the attrs themselves
-  const context: ExecutionContext & Props = { ...props, theme };
+  const context: ExecutionContext & Props = { ...props, blueprint: theme };
   const resolvedAttrs: BaseExtensibleObject = {};
 
   attrs.forEach(attrDef => {

--- a/packages/styled-components/src/models/ThemeProvider.tsx
+++ b/packages/styled-components/src/models/ThemeProvider.tsx
@@ -33,7 +33,7 @@ type ThemeArgument = DefaultTheme | ThemeFn;
 
 type Props = {
   children?: React.ReactChild;
-  theme: ThemeArgument;
+  blueprint: ThemeArgument;
 };
 
 export const ThemeContext = React.createContext<DefaultTheme | undefined>(undefined);
@@ -72,8 +72,8 @@ function mergeTheme(theme: ThemeArgument, outerTheme?: DefaultTheme): DefaultThe
 export default function ThemeProvider(props: Props): JSX.Element | null {
   const outerTheme = useContext(ThemeContext);
   const themeContext = useMemo(
-    () => mergeTheme(props.theme, outerTheme),
-    [props.theme, outerTheme]
+    () => mergeTheme(props.blueprint, outerTheme),
+    [props.blueprint, outerTheme]
   );
 
   if (!props.children) {

--- a/packages/styled-components/src/models/test/ThemeProvider.test.tsx
+++ b/packages/styled-components/src/models/test/ThemeProvider.test.tsx
@@ -13,17 +13,17 @@ describe('ThemeProvider', () => {
   });
 
   it('should not throw an error when no children are passed', () => {
-    TestRenderer.create(<ThemeProvider theme={{}} />);
+    TestRenderer.create(<ThemeProvider blueprint={{}} />);
   });
 
   it("should accept a theme prop that's a plain object", () => {
-    TestRenderer.create(<ThemeProvider theme={{ main: 'black' }} />);
+    TestRenderer.create(<ThemeProvider blueprint={{ main: 'black' }} />);
   });
 
   it('should render its child', () => {
     const child = <p>Child!</p>;
     const wrapper = TestRenderer.create(
-      <ThemeProvider theme={{ main: 'black' }}>{child}</ThemeProvider>
+      <ThemeProvider blueprint={{ main: 'black' }}>{child}</ThemeProvider>
     );
 
     expect(wrapper.toJSON()).toMatchSnapshot();
@@ -37,8 +37,8 @@ describe('ThemeProvider', () => {
     const MyDivWithTheme = withTheme(MyDiv);
 
     const wrapper = TestRenderer.create(
-      <ThemeProvider theme={outerTheme}>
-        <ThemeProvider theme={innerTheme}>
+      <ThemeProvider blueprint={outerTheme}>
+        <ThemeProvider blueprint={innerTheme}>
           <MyDivWithTheme />
         </ThemeProvider>
       </ThemeProvider>
@@ -59,9 +59,9 @@ describe('ThemeProvider', () => {
     const MyDivWithTheme = withTheme(MyDiv);
 
     const wrapper = TestRenderer.create(
-      <ThemeProvider theme={outerestTheme}>
-        <ThemeProvider theme={outerTheme}>
-          <ThemeProvider theme={innerTheme}>
+      <ThemeProvider blueprint={outerestTheme}>
+        <ThemeProvider blueprint={outerTheme}>
+          <ThemeProvider blueprint={innerTheme}>
             <MyDivWithTheme />
           </ThemeProvider>
         </ThemeProvider>
@@ -88,10 +88,10 @@ describe('ThemeProvider', () => {
 
     const wrapper = TestRenderer.create(
       <div>
-        <ThemeProvider theme={themes.one}>
+        <ThemeProvider blueprint={themes.one}>
           <MyDivWithThemeOne />
         </ThemeProvider>
-        <ThemeProvider theme={themes.two}>
+        <ThemeProvider blueprint={themes.two}>
           <MyDivWithThemeTwo />
         </ThemeProvider>
       </div>
@@ -112,8 +112,8 @@ describe('ThemeProvider', () => {
     const MyDivWithTheme = withTheme(MyDiv);
 
     const getJSX = (givenTheme = theme) => (
-      <ThemeProvider theme={givenTheme}>
-        <ThemeProvider theme={augment}>
+      <ThemeProvider blueprint={givenTheme}>
+        <ThemeProvider blueprint={augment}>
           <MyDivWithTheme />
         </ThemeProvider>
       </ThemeProvider>

--- a/packages/styled-components/src/native/test/native.test.tsx
+++ b/packages/styled-components/src/native/test/native.test.tsx
@@ -54,7 +54,7 @@ describe('native', () => {
     const Inner = styled.View``;
 
     Inner.defaultProps = {
-      theme: {
+      blueprint: {
         fontSize: 12,
       },
       style: {
@@ -65,7 +65,7 @@ describe('native', () => {
     const Outer = styled(Inner)``;
 
     Outer.defaultProps = {
-      theme: {
+      blueprint: {
         fontSize: 16,
       },
       style: {
@@ -75,11 +75,11 @@ describe('native', () => {
 
     expect(Outer.defaultProps).toMatchInlineSnapshot(`
       Object {
+        "blueprint": Object {
+          "fontSize": 16,
+        },
         "style": Object {
           "backgroundColor": "silver",
-        },
-        "theme": Object {
-          "fontSize": 16,
         },
       }
     `);
@@ -335,11 +335,11 @@ describe('native', () => {
 
     it('function form allows access to theme', () => {
       const Comp = styled.Text.attrs(props => ({
-        'data-color': props.theme.color,
+        'data-color': props.blueprint.color,
       }))``;
 
       const wrapper = TestRenderer.create(
-        <ThemeProvider theme={{ color: 'red' }}>
+        <ThemeProvider blueprint={{ color: 'red' }}>
           <Comp>Something else</Comp>
         </ThemeProvider>
       );
@@ -354,10 +354,12 @@ describe('native', () => {
 
     it('theme prop works', () => {
       const Comp = styled.Text`
-        color: ${({ theme }) => theme.myColor};
+        color: ${({ blueprint }) => blueprint.myColor};
       `;
 
-      const wrapper = TestRenderer.create(<Comp theme={{ myColor: 'red' }}>Something else</Comp>);
+      const wrapper = TestRenderer.create(
+        <Comp blueprint={{ myColor: 'red' }}>Something else</Comp>
+      );
       const text = wrapper.root.findByType(Text);
 
       expect(text.props.style).toMatchObject({ color: 'red' });
@@ -365,9 +367,9 @@ describe('native', () => {
 
     it('theme in defaultProps works', () => {
       const Comp = styled.Text`
-        color: ${({ theme }) => theme.myColor};
+        color: ${({ blueprint }) => blueprint.myColor};
       `;
-      Comp.defaultProps = { theme: { myColor: 'red' } };
+      Comp.defaultProps = { blueprint: { myColor: 'red' } };
 
       const wrapper = TestRenderer.create(<Comp>Something else</Comp>);
       const text = wrapper.root.findByType(Text);

--- a/packages/styled-components/src/test/attrs.test.tsx
+++ b/packages/styled-components/src/test/attrs.test.tsx
@@ -74,12 +74,12 @@ describe('attrs', () => {
 
   it('function form allows access to theme', () => {
     const Comp = styled.button.attrs(props => ({
-      'data-color': props.theme!.color,
+      'data-color': props.blueprint!.color,
     }))``;
 
     expect(
       TestRenderer.create(
-        <ThemeProvider theme={{ color: 'red' }}>
+        <ThemeProvider blueprint={{ color: 'red' }}>
           <Comp />
         </ThemeProvider>
       ).toJSON()
@@ -93,11 +93,11 @@ describe('attrs', () => {
 
   it('defaultProps are merged into what function attrs receives', () => {
     const Comp = styled.button.attrs(props => ({
-      'data-color': props.theme!.color,
+      'data-color': props.blueprint!.color,
     }))``;
 
     Comp.defaultProps = {
-      theme: {
+      blueprint: {
         color: 'red',
       },
     };

--- a/packages/styled-components/src/test/theme.test.tsx
+++ b/packages/styled-components/src/test/theme.test.tsx
@@ -15,11 +15,11 @@ describe('theming', () => {
 
   it('should inject props.theme into a styled component', () => {
     const Comp = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
     const theme = { color: 'black' };
     TestRenderer.create(
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <Comp />
       </ThemeProvider>
     );
@@ -32,11 +32,11 @@ describe('theming', () => {
 
   it('should inject props.theme into a styled component multiple levels deep', () => {
     const Comp = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
     const theme = { color: 'black' };
     TestRenderer.create(
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <div>
           <div>
             <Comp />
@@ -53,11 +53,11 @@ describe('theming', () => {
 
   it('should properly allow a component to fallback to its default props when a theme is not provided', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.test.color};
+      color: ${props => props.blueprint.test.color};
     `;
 
     Comp1.defaultProps = {
-      theme: {
+      blueprint: {
         test: {
           color: 'purple',
         },
@@ -78,11 +78,11 @@ describe('theming', () => {
   // https://github.com/styled-components/styled-components/issues/344
   it('should use ThemeProvider theme instead of defaultProps theme', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.test.color};
+      color: ${props => props.blueprint.test.color};
     `;
 
     Comp1.defaultProps = {
-      theme: {
+      blueprint: {
         test: {
           color: 'purple',
         },
@@ -91,7 +91,7 @@ describe('theming', () => {
     const theme = { test: { color: 'green' } };
 
     TestRenderer.create(
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <Comp1 />
       </ThemeProvider>
     );
@@ -104,11 +104,11 @@ describe('theming', () => {
 
   it('should properly allow a component to override the theme with a prop even if it is equal to defaultProps theme', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.test.color};
+      color: ${props => props.blueprint.test.color};
     `;
 
     Comp1.defaultProps = {
-      theme: {
+      blueprint: {
         test: {
           color: 'purple',
         },
@@ -117,8 +117,8 @@ describe('theming', () => {
     const theme = { test: { color: 'green' } };
 
     TestRenderer.create(
-      <ThemeProvider theme={theme}>
-        <Comp1 theme={{ test: { color: 'purple' } }} />
+      <ThemeProvider blueprint={theme}>
+        <Comp1 blueprint={{ test: { color: 'purple' } }} />
       </ThemeProvider>
     );
     expect(getRenderedCSS()).toMatchInlineSnapshot(`
@@ -130,7 +130,7 @@ describe('theming', () => {
 
   it('should properly allow a component to override the theme with a prop', () => {
     const Comp = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
 
     const theme = {
@@ -139,8 +139,8 @@ describe('theming', () => {
 
     TestRenderer.create(
       <div>
-        <ThemeProvider theme={theme}>
-          <Comp theme={{ color: 'red' }} />
+        <ThemeProvider blueprint={theme}>
+          <Comp blueprint={{ color: 'red' }} />
         </ThemeProvider>
       </div>
     );
@@ -153,16 +153,16 @@ describe('theming', () => {
 
   it('should only inject props.theme into styled components within its child component tree', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.color || 'red'};
+      color: ${props => props.blueprint.color || 'red'};
     `;
     const Comp2 = styled.div`
-      color: ${props => props.theme.color || 'red'};
+      color: ${props => props.blueprint.color || 'red'};
     `;
 
     const theme = { color: 'black' };
     TestRenderer.create(
       <div>
-        <ThemeProvider theme={theme}>
+        <ThemeProvider blueprint={theme}>
           <div>
             <Comp1 />
           </div>
@@ -182,14 +182,14 @@ describe('theming', () => {
 
   it('should inject props.theme into all styled components within the child component tree', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
     const Comp2 = styled.div`
-      background: ${props => props.theme.color};
+      background: ${props => props.blueprint.color};
     `;
     const theme = { color: 'black' };
     TestRenderer.create(
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <div>
           <div>
             <Comp1 />
@@ -210,7 +210,7 @@ describe('theming', () => {
 
   it('should inject new CSS when the theme changes', () => {
     const Comp = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
     const originalTheme = { color: 'black' };
     const newTheme = { color: 'blue' };
@@ -218,7 +218,7 @@ describe('theming', () => {
     // Force render the component
     const renderComp = () => {
       TestRenderer.create(
-        <ThemeProvider theme={theme}>
+        <ThemeProvider blueprint={theme}>
           <Comp />
         </ThemeProvider>
       );
@@ -244,11 +244,11 @@ describe('theming', () => {
 
   it('should properly render with the same theme from default props on re-render', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
 
     Comp1.defaultProps = {
-      theme: {
+      blueprint: {
         color: 'purple',
       },
     };
@@ -272,12 +272,12 @@ describe('theming', () => {
 
   it('should properly update style if theme is changed', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
 
     const wrapper = TestRenderer.create(
       <ThemeProvider
-        theme={{
+        blueprint={{
           color: 'purple',
         }}
       >
@@ -292,7 +292,7 @@ describe('theming', () => {
 
     wrapper.update(
       <ThemeProvider
-        theme={{
+        blueprint={{
           color: 'pink',
         }}
       >
@@ -311,7 +311,7 @@ describe('theming', () => {
 
   it('should properly update style if props used in styles is changed', () => {
     const Comp1 = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
       z-index: ${props => props.zIndex};
     `;
 
@@ -321,7 +321,7 @@ describe('theming', () => {
 
     const wrapper = TestRenderer.create(
       <ThemeProvider
-        theme={{
+        blueprint={{
           color: 'purple',
         }}
       >
@@ -338,7 +338,7 @@ describe('theming', () => {
 
     wrapper.update(
       <ThemeProvider
-        theme={{
+        blueprint={{
           color: 'pink',
         }}
       >
@@ -360,7 +360,7 @@ describe('theming', () => {
     Comp1.defaultProps.zIndex = 1;
     wrapper.update(
       <ThemeProvider
-        theme={{
+        blueprint={{
           color: 'pink',
         }}
       >
@@ -385,14 +385,14 @@ describe('theming', () => {
 
   it('should change the classnames when the theme changes', () => {
     const Comp = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
 
     const originalTheme = { color: 'black' };
     const newTheme = { color: 'blue' };
 
     const Theme = ({ theme }) => (
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <Comp someProps={theme} />
       </ThemeProvider>
     );
@@ -428,7 +428,7 @@ describe('theming', () => {
     const MyDivWithTheme = withTheme(MyDiv);
 
     const wrapper = TestRenderer.create(
-      <ThemeProvider theme={originalTheme}>
+      <ThemeProvider blueprint={originalTheme}>
         <MyDivWithTheme />
       </ThemeProvider>
     );
@@ -444,7 +444,7 @@ describe('theming', () => {
     const newTheme = { color: 'blue' };
 
     const Theme = ({ theme }) => (
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <MyDivWithTheme />
       </ThemeProvider>
     );
@@ -461,17 +461,17 @@ describe('theming', () => {
   // https://github.com/styled-components/styled-components/issues/445
   it('should use ThemeProvider theme instead of defaultProps theme after initial render', () => {
     const Text = styled.div`
-      color: ${props => props.theme.color};
+      color: ${props => props.blueprint.color};
     `;
 
     Text.defaultProps = {
-      theme: {
+      blueprint: {
         color: 'purple',
       },
     };
 
     const Theme = props => (
-      <ThemeProvider theme={{ color: 'green' }}>
+      <ThemeProvider blueprint={{ color: 'green' }}>
         <Text {...props} />
       </ThemeProvider>
     );
@@ -512,7 +512,7 @@ describe('theming', () => {
     const CompWithTheme = withTheme(Comp);
 
     const wrapper = TestRenderer.create(
-      <ThemeProvider theme={{}}>
+      <ThemeProvider blueprint={{}}>
         <CompWithTheme />
       </ThemeProvider>
     );
@@ -534,7 +534,7 @@ describe('theming', () => {
     const ref = React.createRef<Element>();
 
     renderIntoDocument(
-      <ThemeProvider theme={{}}>
+      <ThemeProvider blueprint={{}}>
         <CompWithTheme ref={ref} />
       </ThemeProvider>
     );
@@ -544,7 +544,7 @@ describe('theming', () => {
 
   // https://github.com/styled-components/styled-components/issues/1130
   it('should not break without a ThemeProvider if it has a defaultTheme', () => {
-    const MyDiv: React.FunctionComponent<{ theme: DefaultTheme }> = ({ theme }) => (
+    const MyDiv: React.FunctionComponent<{ blueprint: DefaultTheme }> = ({ blueprint: theme }) => (
       <div>{theme.color}</div>
     );
     const MyDivWithTheme = withTheme(MyDiv);
@@ -560,14 +560,14 @@ describe('theming', () => {
         !msg.includes('You are not using a ThemeProvider') ? consoleWarn(msg) : null
       );
 
-    MyDivWithTheme.defaultProps = { theme };
+    MyDivWithTheme.defaultProps = { blueprint: theme };
 
     const wrapper = TestRenderer.create(<MyDivWithTheme />);
 
     expect(wrapper.root.findByType('div').props.children).toBe('red');
 
     // Change theme
-    MyDivWithTheme.defaultProps = { theme: newTheme };
+    MyDivWithTheme.defaultProps = { blueprint: newTheme };
 
     // Change theme
     wrapper.update(<MyDivWithTheme />);
@@ -592,13 +592,13 @@ describe('theming', () => {
     };
 
     const Comp1 = styled.div`
-      background-color: ${({ theme }) => theme.palette.white};
-      color: ${({ theme }) => theme.palette.black};
+      background-color: ${({ blueprint }) => blueprint.palette.white};
+      color: ${({ blueprint }) => blueprint.palette.black};
     `;
 
     expect(() => {
       TestRenderer.create(
-        <ThemeProvider theme={theme}>
+        <ThemeProvider blueprint={theme}>
           <Comp1 />
         </ThemeProvider>
       );
@@ -624,11 +624,11 @@ describe('theming', () => {
     const theme = new Theme('2px');
 
     const Comp1 = styled.div`
-      border-radius: ${({ theme }) => theme.borderRadius};
+      border-radius: ${({ blueprint }) => blueprint.borderRadius};
     `;
 
     TestRenderer.create(
-      <ThemeProvider theme={theme}>
+      <ThemeProvider blueprint={theme}>
         <Comp1 />
       </ThemeProvider>
     );
@@ -646,7 +646,7 @@ describe('theming', () => {
       // these tests need to be changed to use error boundaries instead
       const mock = jest.spyOn(console, 'error').mockImplementation(() => {});
       TestRenderer.create(
-        <ThemeProvider theme={null}>
+        <ThemeProvider blueprint={null}>
           <div />
         </ThemeProvider>
       );
@@ -660,7 +660,7 @@ describe('theming', () => {
       // these tests need to be changed to use error boundaries instead
       const mock = jest.spyOn(console, 'error').mockImplementation(() => {});
       TestRenderer.create(
-        <ThemeProvider theme={['a', 'b', 'c']}>
+        <ThemeProvider blueprint={['a', 'b', 'c']}>
           <div />
         </ThemeProvider>
       );
@@ -675,7 +675,7 @@ describe('theming', () => {
       const mock = jest.spyOn(console, 'error').mockImplementation(() => {});
       TestRenderer.create(
         // @ts-expect-error invalid input
-        <ThemeProvider theme={42}>
+        <ThemeProvider blueprint={42}>
           <div />
         </ThemeProvider>
       );

--- a/packages/styled-components/src/types.ts
+++ b/packages/styled-components/src/types.ts
@@ -43,11 +43,11 @@ export interface ExtensibleObject extends BaseExtensibleObject {
   $forwardedAs?: KnownTarget;
   as?: KnownTarget;
   forwardedAs?: KnownTarget;
-  theme?: DefaultTheme;
+  blueprint?: DefaultTheme;
 }
 
 export interface ExecutionContext extends ExtensibleObject {
-  theme: DefaultTheme;
+  blueprint: DefaultTheme;
 }
 
 export interface StyleFunction<Props = ExecutionContext> {

--- a/packages/styled-components/src/utils/determineTheme.ts
+++ b/packages/styled-components/src/utils/determineTheme.ts
@@ -6,5 +6,9 @@ export default function determineTheme(
   providedTheme: any,
   defaultProps: any = EMPTY_OBJECT
 ) {
-  return (props.theme !== defaultProps.theme && props.theme) || providedTheme || defaultProps.theme;
+  return (
+    (props.blueprint !== defaultProps.blueprint && props.blueprint) ||
+    providedTheme ||
+    defaultProps.blueprint
+  );
 }

--- a/packages/styled-components/src/utils/test/determineTheme.test.ts
+++ b/packages/styled-components/src/utils/test/determineTheme.test.ts
@@ -2,8 +2,8 @@ import determineTheme from '../determineTheme';
 
 const theme = { color: 'red' };
 const fallback = { color: 'blue' };
-const props = { theme };
-const defaultProps = { theme: fallback };
+const props = { blueprint: theme };
+const defaultProps = { blueprint: fallback };
 
 describe('determineTheme', () => {
   it('should take precedence over ThemeProvider', () => {


### PR DESCRIPTION
Demo implementation of changes necessary to rename the prop that styled-components uses to theme itself. Useful for conversions.

ref to an ancient issue - https://github.com/styled-components/styled-components/issues/884